### PR TITLE
fix copying balance

### DIFF
--- a/lib/widgets/accountDetails.js
+++ b/lib/widgets/accountDetails.js
@@ -127,7 +127,7 @@ class AccountDetails extends AbstractWidget {
   initWallet() {
     // Content in rows is copied to clipboard on [enter] or double-click
     this.table.rows.on('select', (node) => {
-      const words = node.content.match(/\ *(\w*)\ *$/);
+      const words = node.content.match(/\ *([\w\.]*)\ *$/);
       const value = words[words.length - 1];
 
       copy(value, (err) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "palmreader",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "palmreader",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "blessed": "github:pinheadmz/blessed",


### PR DESCRIPTION
Double clicking before would copy only what's after the "." in the balance.

For example for the balance "12345.54321" only the "54321" would be copied.