### PR TITLE
update examples in updateRecords modal

### DIFF
--- a/lib/modals/updateRecords.js
+++ b/lib/modals/updateRecords.js
@@ -20,9 +20,9 @@ class UpdateRecords extends AbstractModal {
         'Leave completely blank to register without any data.\n\n' +
         'Examples:\n' +
         ' DS 24620 8 2 297595dc199b947aa8650923619436fbdfd99fd625195111ab4efe950900cade\n' +
-        ' NS ns1.palmreader\n' +
-        ' GLUE4 ns1.palmreader 100.200.30.40\n' +
-        ' GLUE6 ns1.palmreader 9530:f7fb:dc28:c1a3:d17f:d3f0:b875:aba8\n' +
+        ' NS ns1.palmreader.\n' +
+        ' GLUE4 ns1.palmreader. 100.200.30.40\n' +
+        ' GLUE6 ns1.palmreader. 9530:f7fb:dc28:c1a3:d17f:d3f0:b875:aba8\n' +
         ' SYNTH4 100.200.30.40\n' +
         ' SYNTH6 9530:f7fb:dc28:c1a3:d17f:d3f0:b875:aba8\n' +
         ' TXT The entire rest of the line is one string without quotes',


### PR DESCRIPTION
the examples in the modal didn't have the period after hostnames for NS and GLUE records which need to be there to actually submit the update.