### PR TITLE
add clear button to updateRecords

### DIFF
--- a/lib/modals/updateRecords.js
+++ b/lib/modals/updateRecords.js
@@ -55,6 +55,18 @@ class UpdateRecords extends AbstractModal {
     });
     addButton(
       this.widget,
+      'CLEAR',
+      {
+        bottom: 1,
+        right: 12
+      }
+    ).on('press', () => {
+      this.records.clearValue();
+      this.records.screen.render();
+      this.records.focus();
+    });
+    addButton(
+      this.widget,
       'UPDATE',
       {
         bottom: 1,


### PR DESCRIPTION
When adding all new NS/DS it's frustrating to hold backspace for ages until it all clears before you can type/paste the new records. Added a simple clear button to solve that.